### PR TITLE
細かい改善

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -245,14 +245,8 @@ impl Game {
                 &r.white_brush,
                 angle,
             );
-        } else {
-            rt.fill_rect(&rect_wh(mini_map_x, mini_map_y, 256, 256), &r.white_brush);
         }
 
-        rt.fill_rect(
-            &rect_wh(0, 48 + 256 + 12, 48 * 3 + 256 * 2, 20),
-            &r.white_brush,
-        );
         if self.is_goal {
             let text = format!(
                 "ゴール！　スコア：{}点　リスタート：Enterキー　終了：ESCキー",

--- a/src/game.rs
+++ b/src/game.rs
@@ -53,7 +53,7 @@ impl Game {
         rand::thread_rng().fill(&mut rng_seed);
         let mut rng = rand_chacha::ChaCha8Rng::from_seed(rng_seed);
 
-        let map = Map::new(&mut rng, 23, 23);
+        let map = Map::new(&mut rng, 21, 21);
         let player = Player {
             x: map.start_x,
             y: map.start_y,

--- a/src/map.rs
+++ b/src/map.rs
@@ -20,17 +20,17 @@ impl Map {
     pub fn new(rng: &mut impl Rng, width: u32, height: u32) -> Self {
         let mut data = vec![Tile::Wall; (width * height) as usize];
 
-        for y in 2..(height - 2) {
-            for x in 2..(width - 2) {
-                if x % 2 != 0 && y % 2 != 0 {
+        for y in 1..(height - 1) {
+            for x in 1..(width - 1) {
+                if x % 2 != 1 && y % 2 != 1 {
                     continue;
                 }
                 data[(x + y * width) as usize] = Tile::Floor;
             }
         }
 
-        for y in (3..(height - 3)).step_by(2) {
-            let x = 3u32;
+        for y in (2..(height - 2)).step_by(2) {
+            let x = 2u32;
             let is_horizontal: bool = rng.gen();
             if is_horizontal {
                 let new_x: u32 = if rng.gen() { x + 1 } else { x - 1 };
@@ -41,8 +41,8 @@ impl Map {
             }
         }
 
-        for x in (5..(width - 3)).step_by(2) {
-            for y in (3..(height - 3)).step_by(2) {
+        for x in (4..(width - 2)).step_by(2) {
+            for y in (2..(height - 2)).step_by(2) {
                 let is_horizontal: bool = rng.gen();
                 if is_horizontal {
                     let new_x: u32 = x + 1;
@@ -58,10 +58,10 @@ impl Map {
             width,
             height,
             data,
-            start_x: 2,
-            start_y: 2,
-            goal_x: width - 3,
-            goal_y: height - 3,
+            start_x: 1,
+            start_y: 1,
+            goal_x: width - 2,
+            goal_y: height - 2,
         }
     }
 


### PR DESCRIPTION
以下の対応を行いました。

- マップ外周の壁を2マスから1マスに減少
    - 元々C++時代に視界がマップ外を参照するのを防ぐために2マスにしていた
    - Rust化の際にマップ外かどうかのチェックを入れたので不要になった
    - なんだったら外周0マスでも問題ないが、ミニマップの見映えがやや悪くなるので保留
- 不要な白塗り描画を削除
    - 元々GDI時代にウィンドウのHDCに直接描画していた（バックサーフェスを使用していなかった）
    - そのため前回の描画をクリアするために部分的に白塗りしていた
    - 今はDirect2DのClearをDrawの最初に呼んでいるため不要になった
- 乱数のシード値を左上に表示
    - Rust化の際に乱数アルゴリズムを変更し、シードが32バイトになったので、正直表示してもよくわからない